### PR TITLE
ci: windows unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-windows:
+          filters:
+            tags:
+              only: /.*/
       - changelog/generate:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ orbs:
   nancy: ory/nancy@0.0.10
   docs: ory/docs@0.0.4
   golangci: ory/golangci@0.0.4
-  win: circleci/windows@2.4.0
 
 jobs:
   test:
@@ -27,14 +26,6 @@ jobs:
       - run: ./test/e2e/run.sh
       - run: ./test/reload/run.sh
 
-  test-windows:
-    executor: win/default
-    working_directory: /go/src/github.com/ory/oathkeeper
-    steps:
-      - checkout
-      - run: go mod download
-      - run: go test -failfast -timeout=20m ./...
-
 workflows:
   "test, build, and relase":
     jobs:
@@ -47,10 +38,6 @@ workflows:
             tags:
               only: /.*/
       - test:
-          filters:
-            tags:
-              only: /.*/
-      - test-windows:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ orbs:
   nancy: ory/nancy@0.0.10
   docs: ory/docs@0.0.4
   golangci: ory/golangci@0.0.4
+  win: circleci/windows@2.4.0
 
 jobs:
   test:
@@ -25,6 +26,14 @@ jobs:
       - run: test -z "$CIRCLE_PR_NUMBER" && goveralls -service=circle-ci -coverprofile=coverage.txt -repotoken=$COVERALLS_REPO_TOKEN || echo "forks are not allowed to push to coveralls"
       - run: ./test/e2e/run.sh
       - run: ./test/reload/run.sh
+
+  test-windows:
+    executor: win/default
+    working_directory: /go/src/github.com/ory/oathkeeper
+    steps:
+      - checkout
+      - run: go mod download
+      - run: go test -failfast -timeout=20m ./...
 
 workflows:
   "test, build, and relase":

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -1,0 +1,16 @@
+name: Windows go test
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - *
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: go test -failfast -timeout=20m ./...

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -6,7 +6,7 @@ on:
       - master
   push:
     branches:
-      - *
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
So this should add the circleci windows test, but the problem is that the windows executor comes with go1.12 but we need at least go1.14. See this https://app.circleci.com/pipelines/github/ory/oathkeeper/678/workflows/5c2a87cc-24b7-4585-94e9-c521dce0619d/jobs/6815

Do you have an idea how to upgrade that version? I just tried installing go using the official installer on a local windows VM. I could not get it working using `Start-Process msiexec.exe -Wait -ArgumentList '/I E:\go1.15.3.windows-amd64.msi /qn'`, although it did do something. I was inspired by this blog post: https://powershellexplained.com/2016-10-21-powershell-installing-msi-files/

Maybe you know how to fix that? You can push on my branch and it should run in CCI.